### PR TITLE
fix: await getBody() promise for insomnia v12 compatibility

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,11 +1,12 @@
 module.exports.responseHooks = [
-  ({ response }) => {
-    const responseBody = response.getBody().toString();
-    const textJson = getContent(responseBody);
+  async ({ response }) => {
+    const body = await response.getBody();
+    if (!body) return;
+
+    const textJson = getContent(body.toString());
 
     if (textJson) {
-      const buffer = Buffer.from(textJson);
-      response.setBody(buffer);
+      response.setBody(Buffer.from(textJson));
     }
   },
 ];


### PR DESCRIPTION
fixes #1 

Insomnia v11.0.1+ changed `getBody()` to return a promise instead of a buffer directly.
The hook was calling `.toString()` on the unresolved promise, which produced the `[object Promise]` that was seen in the issue, instead of the actual response content.